### PR TITLE
Fix missing keys when trimming a mot animation

### DIFF
--- a/HSDRawViewer/Converters/Animation/MOTLoader.cs
+++ b/HSDRawViewer/Converters/Animation/MOTLoader.cs
@@ -266,7 +266,7 @@ namespace HSDRawViewer.Converters
 
         public List<MOT_KEY> Keys = new List<MOT_KEY>();
 
-        public MOT_KEY GetKey(float frame)
+        public MOT_KEY GetKey(float time)
         {
             if (Keys.Count == 0)
                 return null;
@@ -274,20 +274,20 @@ namespace HSDRawViewer.Converters
             if (Keys.Count == 1)
                 return Keys[0];
 
-            if (frame < Keys[0].Time)
+            if (Keys[0].Time > time)
                 return Keys[0];
 
-            var index = Keys.FindIndex(e => frame < e.Time) - 1;
+            // Keys.FindIndex should not return 0 here due to above check
+            var index = Keys.FindIndex(e => e.Time > time) - 1;
             
+            // If index is negative all keys come before the provided time, pick the last one
             if (index < 0)
-                return Keys[0];
-
-            if (index + 1 >= Keys.Count - 1)
                 return Keys[Keys.Count - 1];
 
-            var weight = (frame - Keys[index].Time) / (Keys[index + 1].Time - Keys[index].Time);
+            var weight = (time - Keys[index].Time) / (Keys[index + 1].Time - Keys[index].Time);
             return new MOT_KEY()
             {
+                Time = time,
                 X = AnimationInterpolationHelper.Lerp(Keys[index].X, Keys[index + 1].X, weight),
                 Y = AnimationInterpolationHelper.Lerp(Keys[index].Y, Keys[index + 1].Y, weight),
                 Z = AnimationInterpolationHelper.Lerp(Keys[index].Z, Keys[index + 1].Z, weight),

--- a/HSDRawViewer/Rendering/Animation/MOTAnimManager.cs
+++ b/HSDRawViewer/Rendering/Animation/MOTAnimManager.cs
@@ -32,6 +32,10 @@ namespace HSDRawViewer.Rendering
             foreach (var j in joints)
             {
                 var key = j.GetKey(frame / 60f);
+                if (key == null)
+                {
+                    continue;
+                }
 
                 if (j.TrackFlag.HasFlag(MOT_FLAGS.TRANSLATE))
                 {

--- a/HSDRawViewer/Rendering/Animation/MOTAnimManager.cs
+++ b/HSDRawViewer/Rendering/Animation/MOTAnimManager.cs
@@ -2,6 +2,8 @@
 using System;
 using HSDRaw.Common;
 using OpenTK;
+using System.Diagnostics;
+using System.Collections.Generic;
 
 namespace HSDRawViewer.Rendering
 {
@@ -92,16 +94,41 @@ namespace HSDRawViewer.Rendering
         public override void Trim(int startFrame, int endFrame)
         {
             FrameCount = endFrame - startFrame;
+            _motFile.EndTime = 0f;
             foreach (var j in _motFile.Joints)
             {
-                j.Keys = j.Keys.FindAll(k => k.Time >= startFrame / 60f && k.Time < endFrame / 60f);
+                var startKey = j.GetKey(startFrame / 60f);
+                var endKey = j.GetKey(endFrame / 60f);
+                var middleKeys = j.Keys.FindAll(k => k.Time >= startFrame / 60f && k.Time <= endFrame / 60f);
+
+                j.Keys = new List<MOT_KEY>();
+                if (middleKeys.Count == 0)
+                {
+                    j.Keys.Add(startKey);
+                    j.Keys.Add(endKey);
+                } else
+                {
+                    if (middleKeys[0].Time - startKey.Time > 0.001)
+                    {
+                        j.Keys.Add(startKey);
+                    }
+
+                    j.Keys.AddRange(middleKeys);
+
+                    if (endKey.Time - middleKeys[middleKeys.Count - 1].Time > 0.001)
+                    {
+                        j.Keys.Add(endKey);
+                    }
+                }
+
+                Debug.Assert(j.Keys.Count > 0);
                 foreach (var k in j.Keys)
                 {
                     k.Time -= startFrame / 60f;
                 }
-                j.MaxTime = FrameCount / 60f;
+                j.MaxTime = j.Keys[j.Keys.Count - 1].Time;
+                _motFile.EndTime = Math.Max(_motFile.EndTime, j.MaxTime);
             }
-            _motFile.EndTime = FrameCount / 60f;
         }
 
         public MOT_FILE GetMOT()


### PR DESCRIPTION
When trimming animations we sometimes crash due to empty lists of keys. This stems from trims between large gaps in the list of keys, such that the FindAll predicate will return an empty list. To handle this linearly interpolated keys will be inserted and the beginning and end of the list so that information is not lost.