### PR TITLE
Fixes a problem where trimming an animation would break it

### DIFF
--- a/HSDRawViewer/Rendering/Animation/JointAnimManager.cs
+++ b/HSDRawViewer/Rendering/Animation/JointAnimManager.cs
@@ -325,11 +325,44 @@ namespace HSDRawViewer.Rendering
             {
                 foreach (var t in n.Tracks)
                 {
-                    t.Keys = t.Keys.Where(e => e.Frame >= startFrame && e.Frame <= endFrame).ToList();
-                    foreach (var k in t.Keys)
+
+                    // the new set of keys after trimming
+                    List<FOBJKey> newKeys = t.Keys.Where(e => e.Frame >= startFrame && e.Frame <= endFrame).ToList();
+
+                    // if there's not a key on the startframe, it'll create a new one
+                    if (!t.Keys.Any(k => k.Frame == startFrame))
+                    {
+                        FOBJKey start = new FOBJKey()
+                        {
+                            Frame = startFrame,
+                            Tan = 0,
+                            Value = t.GetValue(startFrame),
+                            InterpolationType = GXInterpolationType.HSD_A_OP_LIN
+                        };
+                        newKeys.Insert(0, start);
+                    }
+
+                    // same but for the last frame
+                    if (!t.Keys.Any(k => k.Frame == endFrame))
+                    {
+                        FOBJKey end = new FOBJKey()
+                        {
+                            Frame = endFrame,
+                            Tan = 0,
+                            Value = t.GetValue(endFrame),
+                            InterpolationType = GXInterpolationType.HSD_A_OP_LIN
+                        };
+                        newKeys.Add(end);
+                    }
+
+                    // finally shifts all the keys
+                    foreach (var k in newKeys)
                     {
                         k.Frame -= startFrame;
                     }
+
+                    // assigns the new keys
+                    t.Keys = newKeys;
                 }
             }
         }


### PR DESCRIPTION
Whenever you would trim an animations, the keys outside the trimmed range would be removed. This would break the interpolation as well as cause some joints to not have any starting transformation, causing the animation to look like a half T-pose in the beginning.

This fix solves it by adding a key at the new startFrame and endFrame after trimming.