### PR TITLE
Proj Enum correction

### DIFF
--- a/HSDRaw/Common/HSD_COBJ.cs
+++ b/HSDRaw/Common/HSD_COBJ.cs
@@ -2,9 +2,9 @@
 {
     public enum CameraProjection
     {
-        PERSPECTIVE,
-        FRUSTRUM,
-        ORTHO
+        PERSPECTIVE = 0x1,
+        FRUSTRUM = 0x2,
+        ORTHO = 0x3
     }
     /// <summary>
     /// 


### PR DESCRIPTION
The engine uses a value added by one when enumerating the projection types.