### PR TITLE
Add custom item command support

### DIFF
--- a/HSDRawViewer/HSDRawViewer.csproj
+++ b/HSDRawViewer/HSDRawViewer.csproj
@@ -567,6 +567,9 @@
     <None Include="Resources\ico_hatchling.png" />
     <None Include="Resources\back_checker.png" />
     <None Include="Resources\ico_anim_shape.png" />
+    <None Include="Melee\command_custom_item.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <Content Include="Resources\ico_replace.png" />
     <None Include="Resources\ts_subtract.png" />
     <None Include="Resources\ts_add.png" />

--- a/HSDRawViewer/Melee/command_custom.yml
+++ b/HSDRawViewer/Melee/command_custom.yml
@@ -57,3 +57,36 @@
   - name: Y Position
     bitCount: 16
     hex: true
+
+- code: 0xF1
+  name: Hitbox Extension
+  parameters:
+  - name: Hitbox ID
+    bitCount: 3
+  - name: Apply To All Previous Hitboxes
+    bitCount: 1
+    enums:
+    - false
+    - true
+  - name: Hitlag Multiplier %
+    bitCount: 12
+  - name: SDI Multiplier %
+    bitCount: 12
+  - name: Shieldstun Multiplier %
+    bitCount: 12
+  - name: Hitstun Modifier
+    bitCount: 8
+    signed: true
+  - name: Set Weight
+    bitCount: 1
+    enums:
+      - false
+      - true
+  - name: Angle Flipper
+    bitCount: 2
+    enums:
+      - Regular
+      - Current Facing Direction
+      - Opposite Current Facing Direction
+  - name: Padding
+    bitCount: 5

--- a/HSDRawViewer/Melee/command_custom_item.yml
+++ b/HSDRawViewer/Melee/command_custom_item.yml
@@ -1,0 +1,32 @@
+﻿- code: 0xF1
+  name: Hitbox Extension
+  parameters:
+    - name: Hitbox ID
+      bitCount: 3
+    - name: Apply To All Previous Hitboxes
+      bitCount: 1
+      enums:
+        - false
+        - true
+    - name: Hitlag Multiplier %
+      bitCount: 12
+    - name: SDI Multiplier %
+      bitCount: 12
+    - name: Shieldstun Multiplier %
+      bitCount: 12
+    - name: Hitstun Modifier
+      bitCount: 8
+      signed: true
+    - name: Set Weight
+      bitCount: 1
+      enums:
+        - false
+        - true
+    - name: Angle Flipper
+      bitCount: 2
+      enums:
+        - Regular
+        - Current Facing Direction
+        - Opposite Current Facing Direction
+    - name: Padding
+      bitCount: 5

--- a/HSDRawViewer/Tools/SubactionManager.cs
+++ b/HSDRawViewer/Tools/SubactionManager.cs
@@ -225,6 +225,7 @@ namespace HSDRawViewer.Tools
             string isa = "";
             string clrsa = "";
             string csa = "";
+            string cisa = "";
             string rsa = "";
 
             string controlPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"Melee\command_controls.yml");
@@ -232,6 +233,7 @@ namespace HSDRawViewer.Tools
             string itemPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"Melee\command_item.yml");
             string colorPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"Melee\command_color.yml");
             string customPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"Melee\command_custom.yml");
+            string customItemPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"Melee\command_custom_item.yml");
             string riderPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"Melee\command_rider.yml");
 
             if (File.Exists(controlPath))
@@ -249,6 +251,9 @@ namespace HSDRawViewer.Tools
             if (File.Exists(customPath))
                 csa = File.ReadAllText(customPath);
 
+            if (File.Exists(customItemPath))
+                cisa = File.ReadAllText(customPath);
+            
             if (File.Exists(riderPath))
                 rsa = File.ReadAllText(riderPath);
 
@@ -257,6 +262,7 @@ namespace HSDRawViewer.Tools
             var isubs = deserializer.Deserialize<Subaction[]>(isa);
             var csubs = deserializer.Deserialize<Subaction[]>(clrsa);
             var customsubs = deserializer.Deserialize<Subaction[]>(csa);
+            var customitemsubs = deserializer.Deserialize<Subaction[]>(cisa);
             var ridersubs = deserializer.Deserialize<Subaction[]>(rsa);
 
             if (subs != null && subs.Length != 0)
@@ -308,6 +314,13 @@ namespace HSDRawViewer.Tools
                     s.IsCustom = true;
                 _customSubactions.AddRange(customsubs);
                 _fighterSubactions.AddRange(customsubs);
+            }
+            if (customitemsubs != null && customitemsubs.Length != 0)
+            {
+                foreach (var s in customitemsubs)
+                    s.IsCustom = true;
+                _customSubactions.AddRange(customitemsubs);
+                _itemSubactions.AddRange(customitemsubs);
             }
         }
 


### PR DESCRIPTION
Add custom item commands support by creating a new file called `command_custom_item.yml`.

Some custom subaction events don't always work for fighters or items so it's nice to separate the two.