### PR TITLE
Support 8 hitboxes

### DIFF
--- a/HSDRawViewer/GUI/Plugins/Melee/SubactionProcessor.cs
+++ b/HSDRawViewer/GUI/Plugins/Melee/SubactionProcessor.cs
@@ -35,7 +35,7 @@ namespace HSDRawViewer.GUI.Plugins.Melee
 
         private List<Command> Commands = new List<Command>();
 
-        public Hitbox[] Hitboxes { get; internal set; } = new Hitbox[4];
+        public Hitbox[] Hitboxes { get; internal set; } = new Hitbox[8];
 
         public bool HitboxesActive { get => Hitboxes.Any(e => e.Active); }
 


### PR DESCRIPTION
I'm thinking about releasing a mod that allows up to 8 hitboxes for Melee. Technically, most subaction commands support up to ID 7 so I edited HSDraw to support the rendering of 8 hitboxes instead of the usual 4. However, since this does depend on an external mod, I'm not sure if this is okay for me to add into the main HSDraw program. Let me know if this is okay with you!