### PR TITLE
Add Menu Option to Import Model Info Sheet

### DIFF
--- a/HSDRawViewer/ContextMenus/JOBJContextMenu.cs
+++ b/HSDRawViewer/ContextMenus/JOBJContextMenu.cs
@@ -24,6 +24,21 @@ namespace HSDRawViewer.ContextMenus
             };
             Items.Add(Import);
 
+            ToolStripMenuItem ImportSheet = new ToolStripMenuItem("Import Model Info Sheet From File");
+            ImportSheet.Click += (sender, args) =>
+            {
+                if (MainForm.SelectedDataNode.Accessor is HSD_JOBJ root)
+                {
+                    MainForm.SelectedDataNode.Collapse();
+                    var f = Tools.FileIO.OpenFile("JSON (*.json)|*.json");
+                    if (f != null)
+                    {
+                        ModelInfoSheet infoSheet = ModelInfoSheet.Import(f);
+                        infoSheet.updateJobj(root);
+                    }
+                }
+            };
+            Items.Add(ImportSheet);
 
             ToolStripMenuItem GenerateMatAnimJoint = new ToolStripMenuItem("Generate and Export MatAnimJoint Structure");
             GenerateMatAnimJoint.Click += (sender, args) =>

--- a/HSDRawViewer/Converters/ModelExporter.cs
+++ b/HSDRawViewer/Converters/ModelExporter.cs
@@ -102,7 +102,6 @@ namespace HSDRawViewer.Converters
             if (settings.ExportModelInfoSheet)
             {
                 ModelInfoSheet.Export(settings.Directory + "model_sheet.json", rootJOBJ);
-                ModelInfoSheet.Import(settings.Directory + "model_sheet.json");
             }
 
             IOManager.ExportScene(exp.Scene, filePath, exportsettings);

--- a/HSDRawViewer/Converters/ModelExporter.cs
+++ b/HSDRawViewer/Converters/ModelExporter.cs
@@ -102,6 +102,7 @@ namespace HSDRawViewer.Converters
             if (settings.ExportModelInfoSheet)
             {
                 ModelInfoSheet.Export(settings.Directory + "model_sheet.json", rootJOBJ);
+                ModelInfoSheet.Import(settings.Directory + "model_sheet.json");
             }
 
             IOManager.ExportScene(exp.Scene, filePath, exportsettings);

--- a/HSDRawViewer/Converters/ModelInfoSheet.cs
+++ b/HSDRawViewer/Converters/ModelInfoSheet.cs
@@ -102,6 +102,17 @@ namespace HSDRawViewer.Converters
         /// 
         /// </summary>
         /// <param name="filepath"></param>
+        public static void Import(string filepath)
+        {
+            string json = File.ReadAllText(filepath);
+            ModelInfoSheet? thing = JsonSerializer.Deserialize<ModelInfoSheet>(json);
+            Console.WriteLine(json);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="filepath"></param>
         /// <param name="root"></param>
         public static void Export(string filepath, HSD_JOBJ root)
         {

--- a/HSDRawViewer/Converters/ModelInfoSheet.cs
+++ b/HSDRawViewer/Converters/ModelInfoSheet.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
+using System.Windows.Forms;
 
 namespace HSDRawViewer.Converters
 {
@@ -95,6 +96,22 @@ namespace HSDRawViewer.Converters
 
         public void updateJobj(HSD_JOBJ jobj)
         {
+            int sheetSize = Objects.Count;
+            int nodeSize = 0;
+            foreach (var x in jobj.TreeList)
+            {
+                if (x.Dobj != null)
+                {
+                    nodeSize += x.Dobj.List.Count;
+                }
+            }
+            if (sheetSize != nodeSize)
+            {
+                string message = "The model info sheet you are importing has {0} objects but the current model has {1}.";
+                MessageBox.Show(String.Format(message, sheetSize, nodeSize), "Invalid Model Info Sheet");
+                return;
+            }
+
             int objectIndex = 0;
             foreach (var j in jobj.TreeList)
             {

--- a/HSDRawViewer/Converters/ModelInfoSheet.cs
+++ b/HSDRawViewer/Converters/ModelInfoSheet.cs
@@ -95,7 +95,27 @@ namespace HSDRawViewer.Converters
 
         public void updateJobj(HSD_JOBJ jobj)
         {
+            int objectIndex = 0;
+            foreach (var j in jobj.TreeList)
+            {
+                if (j.Dobj != null)
+                {
+                    foreach (var dobj in j.Dobj.List)
+                    {
+                        MI_Object current = this.Objects[objectIndex];
 
+                        var mobj = dobj.Mobj;
+                        var mat = mobj.Material;
+
+                        mat.AmbientColor = System.Drawing.Color.FromArgb(Convert.ToInt32(current.Ambient, 16));
+                        mat.DiffuseColor = System.Drawing.Color.FromArgb(Convert.ToInt32(current.Diffuse, 16));
+                        mat.SpecularColor = System.Drawing.Color.FromArgb(Convert.ToInt32(current.Specular, 16));
+                        mat.Shininess = current.Shininess;
+                        mat.Alpha = current.Alpha;
+                        objectIndex++;
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/HSDRawViewer/Converters/ModelInfoSheet.cs
+++ b/HSDRawViewer/Converters/ModelInfoSheet.cs
@@ -30,7 +30,12 @@ namespace HSDRawViewer.Converters
     {
         private HashSet<byte[]> textures = new HashSet<byte[]>();
 
-        public List<MI_Object> Objects { get; set; } = new List<MI_Object>(); 
+        public List<MI_Object> Objects { get; set; } = new List<MI_Object>();
+
+        public ModelInfoSheet()
+        {
+            // Necessary in order to deserialize
+        }
 
         /// <summary>
         /// 
@@ -88,6 +93,11 @@ namespace HSDRawViewer.Converters
             }
         }
 
+        public void updateJobj(HSD_JOBJ jobj)
+        {
+
+        }
+
         /// <summary>
         /// 
         /// </summary>
@@ -102,11 +112,10 @@ namespace HSDRawViewer.Converters
         /// 
         /// </summary>
         /// <param name="filepath"></param>
-        public static void Import(string filepath)
+        public static ModelInfoSheet Import(string filepath)
         {
             string json = File.ReadAllText(filepath);
-            ModelInfoSheet? thing = JsonSerializer.Deserialize<ModelInfoSheet>(json);
-            Console.WriteLine(json);
+            return JsonSerializer.Deserialize<ModelInfoSheet>(json);
         }
 
         /// <summary>

--- a/HSDRawViewer/GUI/Controls/JObjEditor/JObjEditorNew.Designer.cs
+++ b/HSDRawViewer/GUI/Controls/JObjEditor/JObjEditorNew.Designer.cs
@@ -33,6 +33,7 @@
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
             this.toolStripDropDownButton2 = new System.Windows.Forms.ToolStripDropDownButton();
             this.importModelFromFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importModelInfoSheetStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportModelToFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.importSceneSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -97,6 +98,7 @@
             this.toolStripDropDownButton2.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.toolStripDropDownButton2.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.importModelFromFileToolStripMenuItem,
+            this.importModelInfoSheetStripMenuItem,
             this.exportModelToFileToolStripMenuItem,
             this.toolStripSeparator2,
             this.importSceneSettingsToolStripMenuItem,
@@ -113,6 +115,13 @@
             this.importModelFromFileToolStripMenuItem.Size = new System.Drawing.Size(199, 22);
             this.importModelFromFileToolStripMenuItem.Text = "Import Model From File";
             this.importModelFromFileToolStripMenuItem.Click += new System.EventHandler(this.importModelFromFileToolStripMenuItem_Click);
+            // 
+            // importModelInfoSheetStripMenuItem
+            // 
+            this.importModelInfoSheetStripMenuItem.Name = "importModelInfoSheetStripMenuItem";
+            this.importModelInfoSheetStripMenuItem.Size = new System.Drawing.Size(199, 22);
+            this.importModelInfoSheetStripMenuItem.Text = "Import Model Info Sheet From File";
+            this.importModelInfoSheetStripMenuItem.Click += new System.EventHandler(this.importModelInfoSheetToolStripMenuItem_Click);
             // 
             // exportModelToFileToolStripMenuItem
             // 
@@ -373,6 +382,7 @@
         private System.Windows.Forms.ToolStrip toolStrip1;
         private System.Windows.Forms.ToolStripDropDownButton toolStripDropDownButton2;
         private System.Windows.Forms.ToolStripMenuItem importModelFromFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importModelInfoSheetStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exportModelToFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem importSceneSettingsToolStripMenuItem;

--- a/HSDRawViewer/GUI/Controls/JObjEditor/JObjEditorNew.cs
+++ b/HSDRawViewer/GUI/Controls/JObjEditor/JObjEditorNew.cs
@@ -614,6 +614,18 @@ namespace HSDRawViewer.GUI.Controls.JObjEditor
             SetJOBJ(_root);
         }
 
+        private void importModelInfoSheetToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            ClearAnimation();
+            var f = Tools.FileIO.OpenFile("JSON (*.json)|*.json");
+            if (f != null)
+            {
+                ModelInfoSheet infoSheet = ModelInfoSheet.Import(f);
+                infoSheet.updateJobj(_root);
+            }
+            SetJOBJ(_root);
+        }
+
         /// <summary>
         /// 
         /// </summary>


### PR DESCRIPTION
It would be helpful to be able to import model info sheets, so that after I export from HSDRAW, open with Blender to Modify, and re-import into HSDRAW I can keep all the correct settings on each object.

![image](https://github.com/Ploaj/HSDLib/assets/4983605/9324671f-1795-40c6-ad7d-568664fd8406)

![image](https://github.com/Ploaj/HSDLib/assets/4983605/0cf7c05b-a0d7-42cf-9c08-e9e9543cae2a)
